### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Esta Api, segue os mesmos termos de serviço do WhatsApp. É importante que voc�
 	&& apt-get install -y \
 	git \
 	curl \
-	nodejs \
 	yarn \
 	gcc \
 	g++ \
@@ -37,7 +36,6 @@ Esta Api, segue os mesmos termos de serviço do WhatsApp. É importante que voc�
 	libdbus-1-3 \
 	libexpat1 \
 	libfontconfig1 \
-	libgcc1 \
 	libgconf-2-4 \
 	libgdk-pixbuf2.0-0 \
 	libglib2.0-0 \
@@ -61,13 +59,11 @@ Esta Api, segue os mesmos termos de serviço do WhatsApp. É importante que voc�
 	libxtst6 \
 	ca-certificates \
 	fonts-liberation \
-	libappindicator1 \
 	libnss3 \
 	lsb-release \
 	xdg-utils \
 	ca-certificates \
 	fonts-liberation \
-	libappindicator3-1 \
 	libasound2 \
 	libatk-bridge2.0-0 \
 	libatk1.0-0 \


### PR DESCRIPTION
No Debian 11 - mais atual estes pacotes não tem mais ou antigo
nodejs  - o padrão vem com 12 - melhor instalar versão 14
libappindicator3-1 - O pacote libappindicator3-1 não está disponível, mas é referido por outro pacote.
libgcc1 - esta repetido 2 x